### PR TITLE
feat: add body scroll locking feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ By analysing a few projects, most of the logic was identical in every single one
 
 A concern that came from the proposed solution was that every single website has different designs for a navbar or a drawer. Although this is true, their behaviour is usually the same. So, the solution should only deal with logic and behaviours while giving total freedom of the content that is rendered.
 
-⚠️ **Note:** If you are using this package on a `Layout` component that doesn't unmount/remount on each page change, you will probably need to listen to router events so that you make sure you close the drawer even if the page change is triggered by the browser history buttons. See [Router Events](#router-events) section to check how it can be done for Next.js projects.
+⚠️ **Note:** If you are using this package with `[@moxy/next-layout](https://github.com/moxystudio/next-layout)`, where `Layout` components don't unmount on each page change, beware you will have to listen to router events to make sure the drawer closes even if the page change is triggered by the browser's history buttons. See [Handling router events](#handling-router-events) section to check how it can be done in Next.js projects.
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ By analysing a few projects, most of the logic was identical in every single one
 
 A concern that came from the proposed solution was that every single website has different designs for a navbar or a drawer. Although this is true, their behaviour is usually the same. So, the solution should only deal with logic and behaviours while giving total freedom of the content that is rendered.
 
-⚠️ **Note:** If you are using this package on a `Layout` component that doesn't unmount/remount on each page change, you will probably need to listen to router events so that you make sure you close the drawer even if the page change is triggered by the browser history buttons.
+⚠️ **Note:** If you are using this package on a `Layout` component that doesn't unmount/remount on each page change, you will probably need to listen to router events so that you make sure you close the drawer even if the page change is triggered by the browser history buttons. See [Router Events](#router-events) section to check how it can be done for Next.js projects.
 
 ## Usage
 
@@ -87,6 +87,50 @@ Import the styleguide base styles in the app's entry CSS file:
 ```js
 import '@moxy/react-navigation/dist/index.css';
 ```
+
+### Router events
+
+Taking `MyNavigationHelper` component as example:
+
+```js
+import { useRouter } from 'next/router';
+
+const MyNavigationHelper = () => {
+    const router = useRouter();
+
+    const {
+        drawer: {
+            open: openDrawer,
+            close: closeDrawer,
+            toggle: toggleDrawer,
+            isOpen: isDrawerOpen,
+        }
+    } = useNavigation();
+
+    useEffect(() => {
+        const handleRouteChange = () => {
+            closeDrawer();
+        };
+
+        router.events.on('routeChangeStart', handleRouteChange);
+
+        return () => {
+            router.events.off('routeChangeStart', handleRouteChange);
+        };
+    }, [closeDrawer, router.events]);
+
+    return (
+        <>
+            <span>{ `Is Drawer Open?  ${isDrawerOpen}` }</span>
+            <button onClick={ openDrawer }>Open Drawer</button>
+            <button onClick={ closeDrawer }>Close Drawer</button>
+            <button onClick={ toggleDrawer }>Toggle Drawer</button>
+        </>
+    );
+}
+```
+
+We are listening `routeChangeStart` event for the sake of this example. You can check [here](https://nextjs.org/docs/api-reference/next/router#routerevents) a complete list of the supported events for the Next.js Router.
 
 ## Styling
 

--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ const MyNavigationHelper = () => {
 }
 ```
 
-We are listening `routeChangeStart` event for the sake of this example. You can check [here](https://nextjs.org/docs/api-reference/next/router#routerevents) a complete list of the supported events for the Next.js Router.
+We are listening to `routeChangeStart` event for the sake of this example. You can check [here](https://nextjs.org/docs/api-reference/next/router#routerevents) a complete list of the supported events for the Next.js Router.
 
 ## Styling
 

--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ By analysing a few projects, most of the logic was identical in every single one
 
 A concern that came from the proposed solution was that every single website has different designs for a navbar or a drawer. Although this is true, their behaviour is usually the same. So, the solution should only deal with logic and behaviours while giving total freedom of the content that is rendered.
 
+⚠️ **Note:** If you are using this package on a `Layout` component that doesn't unmount/remount on each page change, you will probably need to listen to router events so that you make sure you close the drawer even if the page change is triggered by the browser history buttons.
+
 ## Usage
 
 ```js
@@ -40,7 +42,7 @@ import { NavigationProvider, Navbar, Drawer, useNavigation } from '@moxy/react-n
 
 const MyNavigationHelper = () => {
     const { drawer } = useNavigation();
-    
+
     return (
         <>
             <span>{ `Is Drawer Open?  ${drawer.isOpen}` }</span>
@@ -181,6 +183,12 @@ The placement of the drawer in relation to the viewport.
 Type: `boolean` | Default: `true`
 
 An overlay that renders together with the drawer. When clicked, closes the drawer.
+
+#### lockBodyScroll
+
+Type: `boolean` | Default: `true`
+
+Disables body scroll whenever the drawer is open. It keeps the drawer scroll if needed.
 
 #### className
 

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ Import the styleguide base styles in the app's entry CSS file:
 import '@moxy/react-navigation/dist/index.css';
 ```
 
-### Router events
+### Handling router events
 
 Taking `MyNavigationHelper` component as example:
 

--- a/demo/pages/index.module.css
+++ b/demo/pages/index.module.css
@@ -1,3 +1,4 @@
 .home {
     margin-top: 150px;
+    height: 200vh;
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "@moxy/react-lib-template",
+  "name": "@moxy/react-navigation",
   "version": "1.0.0",
   "lockfileVersion": 1,
   "requires": true,
@@ -3128,6 +3128,11 @@
       "requires": {
         "file-uri-to-path": "1.0.0"
       }
+    },
+    "body-scroll-lock": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/body-scroll-lock/-/body-scroll-lock-3.0.3.tgz",
+      "integrity": "sha512-EUryImgD6Gv87HOjJB/yB2WIGECiZMhmcUK+DrqVRFDDa64xR+FsK0LgvLPnBxZDTxIl+W80/KJ8i6gp2IwOHQ=="
     },
     "boolbase": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "react-dom": "^16.8.0"
   },
   "dependencies": {
+    "body-scroll-lock": "^3.0.3",
     "classnames": "^2.2.6",
     "hoist-non-react-statics": "^3.3.2",
     "prop-types": "^15.7.2"

--- a/src/components/drawer/Drawer.js
+++ b/src/components/drawer/Drawer.js
@@ -1,7 +1,7 @@
 import React, { useCallback, useRef, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
-import { disableBodyScroll, enableBodyScroll, clearAllBodyScrollLocks } from 'body-scroll-lock';
+import { disableBodyScroll, enableBodyScroll } from 'body-scroll-lock';
 
 import { useNavigation } from '../../hooks';
 
@@ -31,8 +31,12 @@ const Drawer = ({
         }
     }, [drawer.isOpen, lockBodyScroll]);
 
-    useEffect(() => () => {
-        clearAllBodyScrollLocks();
+    useEffect(() => {
+        const drawer = drawerRef.current;
+
+        return () => {
+            enableBodyScroll(drawer);
+        };
     }, []);
 
     const handleOverlayClick = useCallback(() => {

--- a/src/components/drawer/Drawer.js
+++ b/src/components/drawer/Drawer.js
@@ -1,15 +1,39 @@
-import React, { useCallback } from 'react';
+import React, { useCallback, useRef, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
+import { disableBodyScroll, enableBodyScroll, clearAllBodyScrollLocks } from 'body-scroll-lock';
+
 import { useNavigation } from '../../hooks';
 
 const drawerClassName = 'react-navigation_drawer';
 
-const Drawer = ({ placement, withOverlay, children, className, overlayClassName }) => {
+const Drawer = ({
+    placement,
+    withOverlay,
+    lockBodyScroll,
+    children,
+    className,
+    overlayClassName,
+}) => {
+    const drawerRef = useRef();
     const { drawer } = useNavigation();
 
     const drawerClassNames = classNames(drawerClassName, `${drawerClassName}-${placement}`, className);
     const overlayClassNames = classNames(`${drawerClassName}-overlay`, overlayClassName);
+
+    useEffect(() => {
+        if (!lockBodyScroll) { return; }
+
+        if (drawer.isOpen) {
+            disableBodyScroll(drawerRef.current);
+        } else {
+            enableBodyScroll(drawerRef.current);
+        }
+    }, [drawer.isOpen, lockBodyScroll]);
+
+    useEffect(() => () => {
+        clearAllBodyScrollLocks();
+    }, []);
 
     const handleOverlayClick = useCallback(() => {
         drawer.close();
@@ -25,6 +49,7 @@ const Drawer = ({ placement, withOverlay, children, className, overlayClassName 
                     onClick={ handleOverlayClick } />
             }
             <div
+                ref={ drawerRef }
                 className={ drawerClassNames }
                 data-open={ drawer.isOpen }
                 data-placement={ placement }>
@@ -37,6 +62,7 @@ const Drawer = ({ placement, withOverlay, children, className, overlayClassName 
 Drawer.propTypes = {
     placement: PropTypes.oneOf(['top', 'right', 'bottom', 'left']),
     withOverlay: PropTypes.bool,
+    lockBodyScroll: PropTypes.bool,
     children: PropTypes.any,
     className: PropTypes.string,
     overlayClassName: PropTypes.string,
@@ -45,6 +71,7 @@ Drawer.propTypes = {
 Drawer.defaultProps = {
     placement: 'left',
     withOverlay: true,
+    lockBodyScroll: true,
 };
 
 export default Drawer;

--- a/src/styles/drawer.css
+++ b/src/styles/drawer.css
@@ -1,6 +1,7 @@
 .react-navigation_drawer {
     position: fixed;
     transition: transform 0.3s ease;
+    overflow: auto;
 
     &[data-open="true"] {
         transform: translate(0, 0);

--- a/tests/components/Drawer.test.js
+++ b/tests/components/Drawer.test.js
@@ -50,27 +50,45 @@ describe('Drawer Component', () => {
     });
 
     it('should disable/enable body scroll when drawer is toggled', () => {
-        const { getByRole } = renderWithProps();
+        const { container, getByRole } = renderWithProps();
+
         const triggerButton = getByRole('button');
+        const drawer = container.querySelector('.react-navigation_drawer');
 
-        expect(enableBodyScroll).toHaveBeenCalled();
-
-        fireEvent.click(triggerButton);
-
-        expect(disableBodyScroll).toHaveBeenCalled();
+        expect(enableBodyScroll).toHaveBeenCalledWith(drawer);
 
         fireEvent.click(triggerButton);
 
-        expect(enableBodyScroll).toHaveBeenCalled();
+        expect(disableBodyScroll).toHaveBeenCalledWith(drawer);
+
+        fireEvent.click(triggerButton);
+
+        expect(enableBodyScroll).toHaveBeenCalledWith(drawer);
     });
 
     it('should not disable body scroll when lockBodyScroll prop is false', () => {
         const { getByRole } = renderWithProps({ lockBodyScroll: false });
         const triggerButton = getByRole('button');
 
+        expect(enableBodyScroll).not.toHaveBeenCalled();
+
         fireEvent.click(triggerButton);
 
-        expect(disableBodyScroll).toHaveBeenCalledTimes(0);
-        expect(enableBodyScroll).toHaveBeenCalledTimes(0);
+        expect(disableBodyScroll).not.toHaveBeenCalled();
+    });
+
+    it('should enable back body scroll whenever the component is unmounted', () => {
+        const { container, getByRole, unmount } = renderWithProps();
+
+        const triggerButton = getByRole('button');
+        const drawer = container.querySelector('.react-navigation_drawer');
+
+        fireEvent.click(triggerButton);
+
+        expect(disableBodyScroll).toHaveBeenCalledWith(drawer);
+
+        unmount();
+
+        expect(enableBodyScroll).toHaveBeenCalledWith(drawer);
     });
 });

--- a/tests/components/Drawer.test.js
+++ b/tests/components/Drawer.test.js
@@ -1,6 +1,21 @@
 import React from 'react';
 import { render, fireEvent } from '@testing-library/react';
-import { NavigationProvider, Drawer } from '../../src';
+import { disableBodyScroll, enableBodyScroll } from 'body-scroll-lock';
+import { NavigationProvider, Drawer, useNavigation } from '../../src';
+
+jest.mock('body-scroll-lock', () => ({
+    disableBodyScroll: jest.fn(),
+    enableBodyScroll: jest.fn(),
+    clearAllBodyScrollLocks: jest.fn(),
+}));
+
+const TriggerButton = () => {
+    const { drawer } = useNavigation();
+
+    return (
+        <button onClick={ drawer.toggle }>Toggle</button> // eslint-disable-line
+    );
+};
 
 const defaultProps = {
     children: <p>Custom Drawer.</p>,
@@ -8,9 +23,14 @@ const defaultProps = {
 
 const renderWithProps = (props = {}) => render(
     <NavigationProvider>
+        <TriggerButton />
         <Drawer { ...defaultProps } { ...props } />
     </NavigationProvider>,
 );
+
+beforeEach(() => {
+    jest.clearAllMocks();
+});
 
 describe('Drawer Component', () => {
     it('should render correctly', () => {
@@ -27,5 +47,30 @@ describe('Drawer Component', () => {
         fireEvent.click(overlay);
 
         expect(asFragment()).toMatchSnapshot();
+    });
+
+    it('should disable/enable body scroll when drawer is toggled', () => {
+        const { getByRole } = renderWithProps();
+        const triggerButton = getByRole('button');
+
+        expect(enableBodyScroll).toHaveBeenCalled();
+
+        fireEvent.click(triggerButton);
+
+        expect(disableBodyScroll).toHaveBeenCalled();
+
+        fireEvent.click(triggerButton);
+
+        expect(enableBodyScroll).toHaveBeenCalled();
+    });
+
+    it('should not disable body scroll when lockBodyScroll prop is false', () => {
+        const { getByRole } = renderWithProps({ lockBodyScroll: false });
+        const triggerButton = getByRole('button');
+
+        fireEvent.click(triggerButton);
+
+        expect(disableBodyScroll).toHaveBeenCalledTimes(0);
+        expect(enableBodyScroll).toHaveBeenCalledTimes(0);
     });
 });

--- a/tests/components/__snapshots__/Drawer.test.js.snap
+++ b/tests/components/__snapshots__/Drawer.test.js.snap
@@ -2,6 +2,9 @@
 
 exports[`Drawer Component should render correctly 1`] = `
 <DocumentFragment>
+  <button>
+    Toggle
+  </button>
   <div
     class="react-navigation_drawer-overlay"
     data-open="false"
@@ -21,6 +24,9 @@ exports[`Drawer Component should render correctly 1`] = `
 
 exports[`Drawer Component should render correctly when overlay is clicked 1`] = `
 <DocumentFragment>
+  <button>
+    Toggle
+  </button>
   <div
     class="react-navigation_drawer-overlay"
     data-open="false"


### PR DESCRIPTION
This MR adds `lockBodyScroll` prop to `Drawer` component so that body scroll can be locked whenever the drawer is open.

⚠️ **Note:** it disables body scroll but it keeps drawer scroll if needed.

 This prop is set to `true` by default. However, this behavior can be changed by setting it to `false`.